### PR TITLE
Feature/40 fix fork

### DIFF
--- a/philo/srcs/actors/philo/_on_fork_released.c
+++ b/philo/srcs/actors/philo/_on_fork_released.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/06 16:32:30 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/06/21 21:41:30 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/06/21 23:07:34 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ void	_on_fork_released(t_philo_actor *self, t_ft_actor *sender)
 		self->has_l_fork = false;
 	if (sender == self->r_fork)
 		self->has_r_fork = false;
-	if (!(self->has_l_fork && self->has_r_fork))
+	if (!self->has_l_fork && !self->has_r_fork)
 	{
 		self->sts = PHILO_STS_SLEEPING;
 		self->sv->tell(self->sv, msg_new(PHILO_EAT_DONE, NULL, NULL));

--- a/philo/srcs/actors/system.c
+++ b/philo/srcs/actors/system.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/10 13:27:01 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/06/17 22:15:58 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/06/21 23:13:43 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -82,8 +82,8 @@ static t_system	*_system_ref(t_system *sys)
 		sys->sv->prop->philos_ref[i] = sys->philos[i]->base;
 		sys->sv->prop->forks_ref[i] = sys->forks[i]->base;
 		sys->philos[i]->sv = sys->sv->base;
-		sys->philos[i]->l_fork = sys->forks[(i - 1) % sys->num]->base;
-		sys->philos[i]->r_fork = sys->forks[i % sys->num]->base;
+		sys->philos[i]->l_fork = sys->forks[i % sys->num]->base;
+		sys->philos[i]->r_fork = sys->forks[(i + 1) % sys->num]->base;
 		ft_actor_set_parent(sys->philos[i]->base, sys->sv->base);
 		ft_actor_set_parent(sys->forks[i]->base, sys->sv->base);
 		i++;


### PR DESCRIPTION
fixed #40

原因は各philoの左右フォークの参照が正しく設定できてなかったのが原因の模様。
初期設定のコードを修正しました。

また、調査中にフォーク開放の条件式を誤っていたのでこちらも修正しています。