### PR TITLE
actor_stop_doneを緊急メッセージで対応

### DIFF
--- a/philo/libs/ft_actor/ft_actor.c
+++ b/philo/libs/ft_actor/ft_actor.c
@@ -6,7 +6,7 @@
 /*   By: ttsubo <ttsubo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 18:08:51 by ttsubo            #+#    #+#             */
-/*   Updated: 2025/07/02 19:53:21 by ttsubo           ###   ########.fr       */
+/*   Updated: 2025/07/03 13:47:27 by ttsubo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,5 +54,5 @@ void	ft_actor_stop(t_ft_actor *a)
 	if (a->v && a->v->on_stop)
 		a->v->on_stop(a);
 	if (a->parent)
-		a->parent->tell(a->parent, msg_new(ACTOR_STOP_DONE, a));
+		a->parent->eg_tell(a->parent, msg_new(ACTOR_STOP_DONE, a));
 }


### PR DESCRIPTION
actorが多い場合にシャットダウンが遅くなる問題が発生していました。
確認した所、ACTOR_STOP_DONEメッセージが通常キューに送信していたので、緊急キューで送信する形に変更しました。